### PR TITLE
fix: xlib name clash for OptimizationLevel

### DIFF
--- a/src/auxiliary/shaderCompiler.cpp
+++ b/src/auxiliary/shaderCompiler.cpp
@@ -57,8 +57,8 @@ std::shared_ptr<ShaderModule> ShaderCompiler::compileShader(std::string_view sou
     shaderc_optimization_level level;
     switch (optimizationLevel)
     {
-    case OptimizationLevel::NoneOpt: level = shaderc_optimization_level_zero; break;
-    case OptimizationLevel::SizeOpt: level = shaderc_optimization_level_size; break;
+    case OptimizationLevel::Disabled: level = shaderc_optimization_level_zero; break;
+    case OptimizationLevel::Compact: level = shaderc_optimization_level_size; break;
     case OptimizationLevel::Performance: level = shaderc_optimization_level_performance; break;
     default: level = shaderc_optimization_level_zero;
     }

--- a/src/auxiliary/shaderCompiler.cpp
+++ b/src/auxiliary/shaderCompiler.cpp
@@ -57,8 +57,8 @@ std::shared_ptr<ShaderModule> ShaderCompiler::compileShader(std::string_view sou
     shaderc_optimization_level level;
     switch (optimizationLevel)
     {
-    case OptimizationLevel::None: level = shaderc_optimization_level_zero; break;
-    case OptimizationLevel::Size: level = shaderc_optimization_level_size; break;
+    case OptimizationLevel::NoneOpt: level = shaderc_optimization_level_zero; break;
+    case OptimizationLevel::SizeOpt: level = shaderc_optimization_level_size; break;
     case OptimizationLevel::Performance: level = shaderc_optimization_level_performance; break;
     default: level = shaderc_optimization_level_zero;
     }

--- a/src/auxiliary/shaderCompiler.h
+++ b/src/auxiliary/shaderCompiler.h
@@ -34,7 +34,7 @@ namespace magma
 
         enum class OptimizationLevel : uint8_t
         {
-            None, Size, Performance
+            NoneOpt, SizeOpt, Performance
         };
 
         /* An abstract interface for mapping an #include request

--- a/src/auxiliary/shaderCompiler.h
+++ b/src/auxiliary/shaderCompiler.h
@@ -34,7 +34,7 @@ namespace magma
 
         enum class OptimizationLevel : uint8_t
         {
-            NoneOpt, SizeOpt, Performance
+            Disabled, Compact, Performance
         };
 
         /* An abstract interface for mapping an #include request


### PR DESCRIPTION
Fixes:
```
magma/src/auxiliary/shaderCompiler.h:37:13: error: expected identifier before numeric constant
   37 |             None, Size, Performance
      |             ^~~~
```