### PR TITLE
Piotr/warnings fix

### DIFF
--- a/src/states/multisampleState.h
+++ b/src/states/multisampleState.h
@@ -29,6 +29,7 @@ namespace magma
         constexpr MultisampleState(uint32_t sampleCount) noexcept;
         constexpr MultisampleState(const MultisampleState&) noexcept;
         constexpr hash_t hash() const noexcept;
+        constexpr MultisampleState& operator=(const MultisampleState&) noexcept;
         constexpr bool operator==(const MultisampleState&) const noexcept;
     };
 

--- a/src/states/multisampleState.inl
+++ b/src/states/multisampleState.inl
@@ -73,6 +73,15 @@ constexpr hash_t MultisampleState::hash() const noexcept
     return hash;
 }
 
+constexpr MultisampleState& MultisampleState::operator=(const MultisampleState& other) noexcept
+{
+    if (this != &other)
+    {
+        VkPipelineMultisampleStateCreateInfo::operator=(other);
+    }
+    return *this;
+}
+
 constexpr bool MultisampleState::operator==(const MultisampleState& other) const noexcept
 {
     return (flags == other.flags) &&

--- a/src/states/rasterizationState.h
+++ b/src/states/rasterizationState.h
@@ -34,6 +34,7 @@ namespace magma
         hash_t chainedHash() const noexcept;
         template<class StructureType>
         const StructureType *findNode(VkStructureType sType) const noexcept;
+        constexpr RasterizationState& operator=(const RasterizationState&) noexcept;
         constexpr bool operator==(const RasterizationState&) const noexcept;
     };
 

--- a/src/states/rasterizationState.inl
+++ b/src/states/rasterizationState.inl
@@ -67,6 +67,15 @@ inline const StructureType *RasterizationState::findNode(VkStructureType sType) 
     return nullptr;
 }
 
+constexpr RasterizationState& RasterizationState::operator=(const RasterizationState& other) noexcept
+{
+    if (this != &other)
+    {
+        VkPipelineRasterizationStateCreateInfo::operator=(other);
+    }
+    return *this;
+}
+
 constexpr bool RasterizationState::operator==(const RasterizationState& other) const noexcept
 {
     return (flags == other.flags) &&


### PR DESCRIPTION
Small fix to suppress compiler warnings.
`warning: implicitly-declared ‘constexpr magma::RasterizationState& magma::RasterizationState::operator=
warning: implicitly-declared ‘constexpr magma::MultisampleState& magma::MultisampleState::operator=
`