### PR TITLE
fix: fixes for asan/ubsan reports, removed destructor calls, zeroing out raw pointers in release()

### DIFF
--- a/src/misc/deviceFaultInfo.cpp
+++ b/src/misc/deviceFaultInfo.cpp
@@ -90,7 +90,7 @@ DeviceFaultInfo& DeviceFaultInfo::operator=(const DeviceFaultInfo& other) noexce
 {
     if (this != &other)
     {
-        this->~DeviceFaultInfo();
+        release();
         pNext = other.pNext;
         core::copyString(description, VK_MAX_DESCRIPTION_SIZE, other.description);
         pAddressInfos = core::copyArray(other.pAddressInfos, other.addressInfoCount);
@@ -107,7 +107,7 @@ DeviceFaultInfo& DeviceFaultInfo::operator=(DeviceFaultInfo&& other) noexcept
 {
     if (this != &other)
     {
-        this->~DeviceFaultInfo();
+        release();
         pNext = other.pNext;
         core::copyString(description, VK_MAX_DESCRIPTION_SIZE, other.description);
         pAddressInfos = other.pAddressInfos;
@@ -129,9 +129,17 @@ DeviceFaultInfo& DeviceFaultInfo::operator=(DeviceFaultInfo&& other) noexcept
 
 DeviceFaultInfo::~DeviceFaultInfo()
 {
+    release();
+}
+
+void DeviceFaultInfo::release()
+{
     delete[] pAddressInfos;
     delete[] pVendorInfos;
     delete[] reinterpret_cast<const uint8_t *>(pVendorBinaryData);
+    pAddressInfos = nullptr;
+    pVendorInfos = nullptr;
+    pVendorBinaryData = nullptr;
 }
 #endif // VK_EXT_device_fault
 } // namespace magma

--- a/src/misc/deviceFaultInfo.h
+++ b/src/misc/deviceFaultInfo.h
@@ -42,6 +42,7 @@ namespace magma
         DeviceFaultInfo& operator=(const DeviceFaultInfo&) noexcept;
         DeviceFaultInfo& operator=(DeviceFaultInfo&&) noexcept;
         ~DeviceFaultInfo();
+        void release();
 
     private:
         uint32_t addressInfoCount;

--- a/src/renderpass/subpass.cpp
+++ b/src/renderpass/subpass.cpp
@@ -106,7 +106,7 @@ SubpassDescription& SubpassDescription::operator=(const SubpassDescription& othe
 {
     if (this != &other)
     {
-        this->~SubpassDescription();
+        release();
         flags = other.flags;
         pipelineBindPoint = other.pipelineBindPoint;
         inputAttachmentCount = other.inputAttachmentCount;
@@ -123,11 +123,21 @@ SubpassDescription& SubpassDescription::operator=(const SubpassDescription& othe
 
 SubpassDescription::~SubpassDescription()
 {
+    release();
+}
+
+void SubpassDescription::release()
+{
     delete[] pInputAttachments;
     delete[] pColorAttachments;
     delete[] pResolveAttachments;
     delete pDepthStencilAttachment;
     delete[] pPreserveAttachments;
+    pInputAttachments = nullptr;
+    pColorAttachments = nullptr;
+    pResolveAttachments = nullptr;
+    pDepthStencilAttachment = nullptr;
+    pPreserveAttachments = nullptr;
 }
 
 hash_t SubpassDescription::getHash() const noexcept

--- a/src/renderpass/subpass.h
+++ b/src/renderpass/subpass.h
@@ -43,6 +43,7 @@ namespace magma
         SubpassDescription& operator=(const SubpassDescription&) noexcept;
         SubpassDescription& operator=(SubpassDescription&&) noexcept;
         ~SubpassDescription();
+        void release();
         hash_t getHash() const noexcept;
     };
 

--- a/src/renderpass/subpass.inl
+++ b/src/renderpass/subpass.inl
@@ -45,7 +45,7 @@ inline SubpassDescription& SubpassDescription::operator=(SubpassDescription&& ot
 {
     if (this != &other)
     {
-        this->~SubpassDescription();
+        release();
         flags = other.flags;
         pipelineBindPoint = other.pipelineBindPoint;
         inputAttachmentCount = other.inputAttachmentCount;

--- a/src/shaders/pipelineShaderStage.cpp
+++ b/src/shaders/pipelineShaderStage.cpp
@@ -80,7 +80,7 @@ PipelineShaderStage& PipelineShaderStage::operator=(const PipelineShaderStage& o
 {
     if (this != &other)
     {
-        this->~PipelineShaderStage();
+        release();
         shaderModule = other.shaderModule;
         specialization = other.specialization;
         flags = other.flags;
@@ -96,7 +96,7 @@ PipelineShaderStage& PipelineShaderStage::operator=(PipelineShaderStage&& other)
 {
     if (this != &other)
     {
-        this->~PipelineShaderStage();
+        release();
         pNext = other.pNext;
         flags = other.flags;
         stage = other.stage;

--- a/src/shaders/pipelineShaderStage.h
+++ b/src/shaders/pipelineShaderStage.h
@@ -39,7 +39,8 @@ namespace magma
         PipelineShaderStage(PipelineShaderStage&&) noexcept;
         PipelineShaderStage& operator=(const PipelineShaderStage&) noexcept;
         PipelineShaderStage& operator=(PipelineShaderStage&&) noexcept;
-        virtual ~PipelineShaderStage() { delete[] pName; }
+        virtual ~PipelineShaderStage() { release(); }
+        virtual void release() { delete[] pName; }
         const std::shared_ptr<ShaderModule>& getShaderModule() const noexcept { return shaderModule; }
         const std::shared_ptr<Specialization>& getSpecialization() const noexcept { return specialization; }
         hash_t getHash() const noexcept;

--- a/src/shaders/specialization.cpp
+++ b/src/shaders/specialization.cpp
@@ -34,7 +34,7 @@ Specialization& Specialization::operator=(const Specialization& other) noexcept
 {
     if (this != &other)
     {
-        this->~Specialization();
+        release();
         mapEntryCount = other.mapEntryCount;
         pMapEntries = core::copyArray(other.pMapEntries, other.mapEntryCount);
         dataSize = other.dataSize;
@@ -45,8 +45,15 @@ Specialization& Specialization::operator=(const Specialization& other) noexcept
 
 Specialization::~Specialization()
 {
+    release();
+}
+
+void Specialization::release()
+{
     delete[] pMapEntries;
     delete[] reinterpret_cast<const uint8_t *>(pData);
+    pMapEntries = nullptr;
+    pData = nullptr;
 }
 
 hash_t Specialization::getHash() const noexcept

--- a/src/shaders/specialization.h
+++ b/src/shaders/specialization.h
@@ -46,6 +46,7 @@ namespace magma
         Specialization& operator=(const Specialization&) noexcept;
         Specialization& operator=(Specialization&&) noexcept;
         ~Specialization();
+        void release();
         hash_t getHash() const noexcept;
     };
 } // namespace magma

--- a/src/shaders/specialization.inl
+++ b/src/shaders/specialization.inl
@@ -49,7 +49,7 @@ inline Specialization& Specialization::operator=(Specialization&& other) noexcep
 {
     if (this != &other)
     {
-        this->~Specialization();
+        release();
         mapEntryCount = other.mapEntryCount;
         pMapEntries = other.pMapEntries;
         dataSize = other.dataSize;

--- a/src/states/vertexInputStructure.h
+++ b/src/states/vertexInputStructure.h
@@ -30,6 +30,7 @@ namespace magma
     public:
         VertexInputStructure() {}
         ~VertexInputStructure();
+        void release();
         explicit VertexInputStructure(uint32_t binding,
             const VertexInputAttribute& attribute,
             VkVertexInputRate inputRate = VK_VERTEX_INPUT_RATE_VERTEX) noexcept;

--- a/src/states/vertexInputStructure.inl
+++ b/src/states/vertexInputStructure.inl
@@ -3,6 +3,12 @@ namespace magma
 template<class Vertex>
 inline VertexInputStructure<Vertex>::~VertexInputStructure()
 {
+    release();
+}
+
+template<class Vertex>
+inline void VertexInputStructure<Vertex>::release()
+{
     pVertexBindingDescriptions = nullptr; // delete[] pVertexBindingDescriptions in VertexInputState will be no-op
 }
 
@@ -78,7 +84,7 @@ inline VertexInputStructure<Vertex>& VertexInputStructure<Vertex>::operator=(con
 {
     if (this != &other)
     {
-        this->~VertexInputStructure();
+        release();
         flags = other.flags;
         vertexBindingDescription = other.vertexBindingDescription;
         vertexBindingDescriptionCount = other.vertexBindingDescriptionCount;


### PR DESCRIPTION
Encountered some segfaults and dig a little bit. Might be platform specific. Not sure if I got 100% of the underlying causes but ASAN/UBSAN do not report anything bad now. Main changes are avoiding manual destructor calls and zeroing out raw pointers. Subpass objects contain pointers that were (and probably still are) deleted twice but now it's asymptomatic due to zeroing out.

`==3422762==ERROR: AddressSanitizer: attempting double-free on 0x502000000630 in thread T0: #0 0x73d0b7eff5e8 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:164 #1 0x6496a0900302 in magma::SubpassDescription::~SubpassDescription() src/renderpass/subpass.cpp:129 #2 0x73d0b5a47381 in __cxa_finalize stdlib/cxa_finalize.c:82 #3 0x73d0b69f60b6 (/usr/local/lib/x86_64-linux-gnu/librubens.so+0x7f60b6) (BuildId: b6c8e1509a271ba4164f362d29bedd0279f33945) 0x502000000630 is located 0 bytes inside of 8-byte region [0x502000000630,0x502000000638) freed by thread T0 here: #0 0x73d0b7eff5e8 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:164 #1 0x6496a0900302 in magma::SubpassDescription::~SubpassDescription() src/renderpass/subpass.cpp:129 #2 0x73d0b5a47a75 in __run_exit_handlers stdlib/exit.c:108 #3 0x73d0b5a47bbd in __GI_exit stdlib/exit.c:138 #4 0x73d0b5a2a1d0 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:74 #5 0x73d0b5a2a28a in __libc_start_main_impl ../csu/libc-start.c:360 #6 0x6496a086a6d4 in _start (/home/piotr/vis/rubens/samples/build/01-clear+0x2086d4) (BuildId: 0ca8d6afc411715c69ed82227b36fe4124d475ce) previously allocated by thread T0 here: #0 0x73d0b7efe840 in operator new(unsigned long, std::nothrow_t const&) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:101 #1 0x6496a08ffe42 in magma::SubpassDescription::SubpassDescription(VkImageLayout, VkImageLayout) src/renderpass/subpass.cpp:51 #2 0x6496a09008f8 in __static_initialization_and_destruction_0 src/renderpass/subpass.cpp:200 #3 0x6496a090092b in _GLOBAL__sub_I_subpass.cpp src/renderpass/subpass.cpp:203 #4 0x73d0b5a2a303 in call_init ../csu/libc-start.c:145 #5 0x73d0b5a2a303 in __libc_start_main_impl ../csu/libc-start.c:347 #6 0x6496a086a6d4 in _start (/home/piotr/vis/rubens/samples/build/01-clear+0x2086d4) (BuildId: 0ca8d6afc411715c69ed82227b36fe4124d475ce) SUMMARY: AddressSanitizer: double-free ../../../../src/libsanitizer/asan/asan_new_delete.cpp:164 in operator delete(void*, unsigned long) ==3422762==ABORTING`